### PR TITLE
Updated available resolutions in setScale command

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -67,7 +67,7 @@ void set_scale(int * data) {
 
     bool check_res (int num) {
         const int items[] = {1, 8, 16, 32, 64, 128 };
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 6; i++)
         {
             if (num == items[i]) return true;
         }

--- a/src/command.c
+++ b/src/command.c
@@ -66,8 +66,8 @@ void set_scale(int * data) {
     data[4] = max_voltage & 0xFF;
 
     bool check_res (int num) {
-        const int items[] = {2, 4, 8, 16, 32, 64, 128 };
-        for (int i = 0; i < 7; i++)
+        const int items[] = {1, 8, 16, 32, 64, 128 };
+        for (int i = 0; i < 5; i++)
         {
             if (num == items[i]) return true;
         }
@@ -75,7 +75,7 @@ void set_scale(int * data) {
     }
 
     do {
-        data[5] = ask_int("Resolution [2-128]:", 2, 128);
+        data[5] = ask_int("Resolution [1,8-128]:", 1, 128);
     } while(!check_res(data[5]));
     data[6] = ask_int("Sampling [1-255]:", 1, 255);
 }


### PR DESCRIPTION
Original Trello issue: [Measurement packets v2](https://trello.com/c/I6uoNBCQ)

Due to the new measurement packet system on Celeritas itself, I've added resolution 1 (which involved the change of the input minimum value) and removed 2, 4 because the new system doesn't use it anymore. 
To make things work I've also adjusted the prompt and the for loop index in `check_res`.

**DO NOT MERGE and release until the main feature is merged!**