### PR TITLE
Resolution settings up to 512 channels (64 packets)

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -66,8 +66,8 @@ void set_scale(int * data) {
     data[4] = max_voltage & 0xFF;
 
     bool check_res (int num) {
-        const int items[] = {1, 8, 16, 32, 64, 128, 256, 512 };
-        for (int i = 0; i < 6; i++)
+        const int items[] = {1, 8, 16, 32, 64, 128, 256, 512, 1024 };
+        for (int i = 0; i < 9; i++)
         {
             if (num == items[i]) return true;
         }

--- a/src/command.c
+++ b/src/command.c
@@ -75,7 +75,7 @@ void set_scale(int * data) {
     }
 
     do {
-        int channel_number = ask_int("Resolution [1,8-512] (numbers of chanels, powers of two):", 1, 512);
+        int channel_number = ask_int("Resolution [1,8-1024] (numbers of chanels, powers of two):", 1, 1024);
         if (channel_number == 1){data[5] = 0;} else {data[5] = channel_number/8;};
     } while(!check_res(data[5]));
     data[6] = ask_int("Sampling [1-255]:", 1, 255);

--- a/src/command.c
+++ b/src/command.c
@@ -66,7 +66,7 @@ void set_scale(int * data) {
     data[4] = max_voltage & 0xFF;
 
     bool check_res (int num) {
-        const int items[] = {1, 8, 16, 32, 64, 128 };
+        const int items[] = {1, 8, 16, 32, 64, 128, 256, 512 };
         for (int i = 0; i < 6; i++)
         {
             if (num == items[i]) return true;
@@ -75,7 +75,8 @@ void set_scale(int * data) {
     }
 
     do {
-        data[5] = ask_int("Resolution [1,8-128]:", 1, 128);
+        int channel_number = ask_int("Resolution [1,8-512] (numbers of chanels, powers of two):", 1, 512);
+        if (channel_number == 1){data[5] = 0;} else {data[5] = channel_number/8;};
     } while(!check_res(data[5]));
     data[6] = ask_int("Sampling [1-255]:", 1, 255);
 }


### PR DESCRIPTION
Minor changes enabling measurements up to 512 channels
resolution byte value, channels:
0, counter mode
1-8
2-16
4-32
8-64
16-128
32-256
64-512
